### PR TITLE
given URL for go get is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ news -wait 30 -dir "D:/gdrive/news"
 ```
 
 ## Running from code
-`go get -u http://github.com/ww9/news`
+`go get -uv github.com/ww9/news`
 
 `cd $GOROOT/src/github.com/ww9/news`
 


### PR DESCRIPTION
```
% go get -u https://github.com/ww9/news 
package https:/github.com/ww9/news: https:/github.com/ww9/news: invali                                     "https:/github.com/ww9/news": invalid char ':'
```
Correct URL is `github.com/ww9/news`. The command is:
```
go get -u github.com/ww9/news
```
